### PR TITLE
Fix package homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"manufacturer": "Samsung",
 	"product": "MD Display",
 	"shortname": "Samsung Display",
-	"homepage": "https://github.com/bitfocus/companion-module-samsung-display-udp#readme",
+	"homepage": "https://github.com/bitfocus/companion-module-samsung-display#readme",
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Fixed the module name / homepage url so that the module will correctly link to Github in Companion. I had to dig for a bit to find this package, as the Companion link (https://github.com/bitfocus/companion-module-samsung-display-udp#readme) 404s